### PR TITLE
Fix enum type mismatch

### DIFF
--- a/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_web.dart
+++ b/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_web.dart
@@ -822,8 +822,7 @@ TableTy? _getTableType(Object value) {
   final t = _getType(value);
   if (t == null) return null;
   final ty = ValueTy.values.firstWhere((value) =>
-      value.toString().split('.').last.toLowerCase() ==
-      (t['element']! as String).toLowerCase());
+      value.name.toLowerCase() == (t['element']! as String).toLowerCase());
   return TableTy(
     element: ty,
     minimum: t['minimum']! as int,

--- a/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_web.dart
+++ b/packages/wasm_run/lib/src/wasm_bindings/_wasm_interop_web.dart
@@ -821,7 +821,9 @@ GlobalTy? _getGlobalType(Object value) {
 TableTy? _getTableType(Object value) {
   final t = _getType(value);
   if (t == null) return null;
-  final ty = ValueTy.values.byName(t['element']! as String);
+  final ty = ValueTy.values.firstWhere((value) =>
+      value.toString().split('.').last.toLowerCase() ==
+      (t['element']! as String).toLowerCase());
   return TableTy(
     element: ty,
     minimum: t['minimum']! as int,


### PR DESCRIPTION
Fix enum type mismatch 'funcref' with 'funcRef'. This fix 'null value' error on Safari. Other browsers (for probably what is the wrong reason) works normally because the flow is interrupted the line before returning null (more about this here https://github.com/juancastillo0/wasm_run/issues/56)